### PR TITLE
Fix for URIs with parameters

### DIFF
--- a/var/www/mason/mason_fcgi.pl
+++ b/var/www/mason/mason_fcgi.pl
@@ -156,7 +156,7 @@ while (my $cgi = new CGI::Fast()) {
   %HTML::Mason::Commands::stash = ();
   
   $ENV{SCRIPT_NAME} = '';
-  $cgi->path_info($ENV{REQUEST_URI});
+  $cgi->path_info($ENV{DOCUMENT_URI});
 
   eval { $handlers{$host}->handle_cgi_object($cgi) };
   if (my $raw_error = $@) {


### PR DESCRIPTION
REQUEST_URI includes any '? ...' parameters in the path, so the server looks for
'/path/to/document?param' instead of '/path/to/document'. So, this isn't
noticible if you don't have parameters attached to your URL.
